### PR TITLE
add fallback for guessing package name from file name

### DIFF
--- a/package_reloader.py
+++ b/package_reloader.py
@@ -37,15 +37,9 @@ class PackageReloaderReloadCommand(sublime_plugin.WindowCommand):
         sublime.set_timeout_async(lambda: self.run_async(pkg_name))
 
     def run_async(self, pkg_name=None):
-        spp = os.path.realpath(sublime.packages_path())
-
         if not pkg_name:
             view = self.window.active_view()
-            file_name = view.file_name()
-            if file_name:
-                file_name = os.path.realpath(file_name)
-                if file_name and file_name.endswith(".py") and spp in file_name:
-                    pkg_name = file_name.replace(spp, "").split(os.sep)[1]
+            pkg_name = self.extract_from_file_name(view.file_name())
 
         if not pkg_name:
             folders = sublime.active_window().folders()
@@ -77,3 +71,18 @@ class PackageReloaderReloadCommand(sublime_plugin.WindowCommand):
                 self.window.run_command("hide_panel", {"panel": "console"})
 
             sublime.status_message("{} reloaded.".format(pkg_name))
+
+    def extract_from_file_name(self, file_name):
+        if not file_name:
+            return None
+
+        spp = os.path.realpath(sublime.packages_path())
+
+        real_file_name = os.path.realpath(file_name)
+        if real_file_name.endswith(".py") and spp in real_file_name:
+            return real_file_name.replace(spp, "").split(os.sep)[1]
+
+        if file_name.endswith(".py") and spp in file_name:
+            return file_name.replace(spp, "").split(os.sep)[1]
+
+        return None


### PR DESCRIPTION
I usually simlink projects into my Packages folder when I'm working on them,
and wasn't able to use the "reload" command because the path was expanded.

I therefore added a fallback to the method that guess the package name from the filename.

The behavior should be the same as before for users for who the plugin was working.

If you have a better idea for the "extract_from_file_name" function name, or if you want me to inline it, please tell me.
