### PR TITLE
fix spelling of preferences command pallet entry

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -8,7 +8,7 @@
         "command": "package_reloader_toggle_reload_on_save"
     },
     {
-        "caption": "Preference: Automatic Package Reloader Settings",
+        "caption": "Preferences: Automatic Package Reloader Settings",
         "command": "edit_settings",
         "args":
         {


### PR DESCRIPTION
Closes #5

Use "Preferences: ..." as command prefix as core and all other packages do.