### PR TITLE
Fixed FileNotFoundError: [WinError 3] The system cannot find the

### DIFF
--- a/reloader/reloader.py
+++ b/reloader/reloader.py
@@ -112,8 +112,8 @@ def reload_missing(modules, verbose):
 
 def reload_plugin(pkg_name):
     pkg_path = os.path.join(os.path.realpath(sublime.packages_path()), pkg_name)
-    plugins = [pkg_name + "." + os.path.splitext(file)[0]
-               for file in os.listdir(pkg_path) if file.endswith(".py")]
+    plugins = [pkg_name + "." + os.path.splitext(file_name)[0]
+               for file_name in os.listdir(pkg_path) if file_name.endswith(".py")]
     for plugin in plugins:
         sublime_plugin.reload_plugin(plugin)
 

--- a/reloader/reloader.py
+++ b/reloader/reloader.py
@@ -44,7 +44,7 @@ def reload_package(pkg_name, dummy=True, verbose=True):
         with intercepting_imports(modules, verbose), \
                 importing_fromlist_aggresively(modules):
 
-            reload_plugin(main.__name__)
+            reload_plugin(pkg_name)
     except Exception:
         dprint("reload failed.", fill='-')
         reload_missing(modules, verbose)
@@ -112,8 +112,8 @@ def reload_missing(modules, verbose):
 
 def reload_plugin(pkg_name):
     pkg_path = os.path.join(os.path.realpath(sublime.packages_path()), pkg_name)
-    plugins = [pkg_name + "." + os.path.splitext(f)[0]
-               for f in os.listdir(pkg_path) if f.endswith(".py")]
+    plugins = [pkg_name + "." + os.path.splitext(file)[0]
+               for file in os.listdir(pkg_path) if file.endswith(".py")]
     for plugin in plugins:
         sublime_plugin.reload_plugin(plugin)
 

--- a/reloader/reloader.py
+++ b/reloader/reloader.py
@@ -112,8 +112,8 @@ def reload_missing(modules, verbose):
 
 def reload_plugin(pkg_name):
     pkg_path = os.path.join(os.path.realpath(sublime.packages_path()), pkg_name)
-    plugins = [pkg_name + "." + os.path.splitext(file_name)[0]
-               for file_name in os.listdir(pkg_path) if file_name.endswith(".py")]
+    plugins = [pkg_name + "." + os.path.splitext(file_path)[0]
+               for file_path in os.listdir(pkg_path) if file_path.endswith(".py")]
     for plugin in plugins:
         sublime_plugin.reload_plugin(plugin)
 


### PR DESCRIPTION
path specified, on windows systems when Sublime Text returns the
file path with the wrong case name. Issue:

1. https://github.com/randy3k/AutomaticPackageReloader/issues/10 FileNotFoundError: [WinError 3] The system cannot find the path specified
