### PR TITLE
Reload dependencies and their dependents.

### DIFF
--- a/reloader/reloader.py
+++ b/reloader/reloader.py
@@ -35,7 +35,7 @@ def dprint(*args, fill=None, fill_width=60, **kwargs):
 # https://github.com/divmain/GitSavvy/blob/599ba3cdb539875568a96a53fafb033b01708a67/common/util/reload.py
 def reload_package(pkg_name, dummy=True, verbose=True):
     if is_dependency(pkg_name):
-        reload_dependency(pkg_name, verbose)
+        reload_dependency(pkg_name, dummy, verbose)
         return
 
     if pkg_name not in sys.modules:
@@ -72,7 +72,7 @@ def reload_package(pkg_name, dummy=True, verbose=True):
         dprint("end", fill='-')
 
 
-def reload_dependency(dependency_name, verbose=True):
+def reload_dependency(dependency_name, dummy=True, verbose=True):
     """
     Package Control dependencies aren't regular packages, so we don't want to
     call `sublime_plugin.unload_module` or `sublime_plugin.reload_plugin`.
@@ -90,7 +90,10 @@ def reload_dependency(dependency_name, verbose=True):
     manager = PackageManager()
     for package in manager.list_packages():
         if dependency_name in manager.get_dependencies(package):
-            reload_package(package, verbose)
+            reload_package(package, dummy=False, verbose=verbose)
+
+    if dummy:
+        load_dummy(verbose)
 
 def load_dummy(verbose):
     """

--- a/reloader/reloader.py
+++ b/reloader/reloader.py
@@ -10,7 +10,16 @@ import types
 from contextlib import contextmanager
 from .stack_meter import StackMeter
 
-from package_control.package_manager import PackageManager
+
+try:
+    from package_control.package_manager import PackageManager
+
+    def is_dependency(pkg_name):
+        return PackageManager()._is_dependency(pkg_name)
+
+except ImportError:
+    def is_dependency(pkg_name):
+        return False
 
 
 def dprint(*args, fill=None, fill_width=60, **kwargs):
@@ -25,7 +34,7 @@ def dprint(*args, fill=None, fill_width=60, **kwargs):
 # check the link for comments
 # https://github.com/divmain/GitSavvy/blob/599ba3cdb539875568a96a53fafb033b01708a67/common/util/reload.py
 def reload_package(pkg_name, dummy=True, verbose=True):
-    if PackageManager()._is_dependency(pkg_name):
+    if is_dependency(pkg_name):
         reload_dependency(pkg_name)
         return
 

--- a/reloader/reloader.py
+++ b/reloader/reloader.py
@@ -73,6 +73,14 @@ def reload_package(pkg_name, dummy=True, verbose=True):
 
 
 def reload_dependency(dependency_name):
+    """
+    Package Control dependencies aren't regular packages, so we don't want to
+    call `sublime_plugin.unload_module` or `sublime_plugin.reload_plugin`.
+    Instead, we manually unload all of the modules in the dependency and then
+    `reload_package` any packages that use that dependency. (We have to manually
+    unload the dependency's modules because calling `reload_package` on a
+    dependent module will not unload the dependency.)
+    """
     dependency_base = os.path.join(sublime.packages_path(), dependency_name) + os.sep
 
     for module in list(sys.modules.values()):

--- a/reloader/reloader.py
+++ b/reloader/reloader.py
@@ -35,7 +35,7 @@ def dprint(*args, fill=None, fill_width=60, **kwargs):
 # https://github.com/divmain/GitSavvy/blob/599ba3cdb539875568a96a53fafb033b01708a67/common/util/reload.py
 def reload_package(pkg_name, dummy=True, verbose=True):
     if is_dependency(pkg_name):
-        reload_dependency(pkg_name)
+        reload_dependency(pkg_name, verbose)
         return
 
     if pkg_name not in sys.modules:
@@ -72,7 +72,7 @@ def reload_package(pkg_name, dummy=True, verbose=True):
         dprint("end", fill='-')
 
 
-def reload_dependency(dependency_name):
+def reload_dependency(dependency_name, verbose=True):
     """
     Package Control dependencies aren't regular packages, so we don't want to
     call `sublime_plugin.unload_module` or `sublime_plugin.reload_plugin`.
@@ -90,7 +90,7 @@ def reload_dependency(dependency_name):
     manager = PackageManager()
     for package in manager.list_packages():
         if dependency_name in manager.get_dependencies(package):
-            reload_package(package)
+            reload_package(package, verbose)
 
 def load_dummy(verbose):
     """

--- a/reloader/reloader.py
+++ b/reloader/reloader.py
@@ -7,7 +7,6 @@ import functools
 import importlib
 import sys
 import types
-import imp
 from contextlib import contextmanager
 from .stack_meter import StackMeter
 
@@ -67,9 +66,9 @@ def reload_package(pkg_name, dummy=True, verbose=True):
 def reload_dependency(dependency_name):
     dependency_base = os.path.join(sublime.packages_path(), dependency_name) + os.sep
 
-    for module in sys.modules.values():
+    for module in list(sys.modules.values()):
         if getattr(module, '__file__', '').startswith(dependency_base):
-            imp.reload(module)
+            del sys.modules[module.__name__]
 
     manager = PackageManager()
     for package in manager.list_packages():


### PR DESCRIPTION
For #12.

When the plugin tries to reload a dependency, it will:

1. Detect that the “package” is a dependency.
2. `imp.reload` all of the loaded modules within the dependency.
3. `reload_package` all of the packages that declare that dependency.

After this PR, when I save a file in my local copy of `sublime_lib`, AutomaticPackageReloader reloads `sublime_lib` and all packages that depend upon it.

This PR does require Package Control to be installed. We can work around that if necessary, at least to a limited extent.