### PR TITLE
Get package modules

### DIFF
--- a/reloader/reloader.py
+++ b/reloader/reloader.py
@@ -110,11 +110,8 @@ def reload_dependency(dependency_name, dummy=True, verbose=True):
     unload the dependency's modules because calling `reload_package` on a
     dependent module will not unload the dependency.)
     """
-    dependency_base = os.path.join(sublime.packages_path(), dependency_name) + os.sep
-
-    for module in list(sys.modules.values()):
-        if getattr(module, '__file__', '').startswith(dependency_base):
-            del sys.modules[module.__name__]
+    for name in get_package_modules(dependency_name):
+        del sys.modules[name]
 
     manager = PackageManager()
     for package in manager.list_packages():

--- a/reloader/reloader.py
+++ b/reloader/reloader.py
@@ -21,12 +21,18 @@ def dprint(*args, fill=None, fill_width=60, **kwargs):
 
 
 def get_package_modules(pkg_name):
-    package_base = os.path.join(sublime.packages_path(), pkg_name)
+    installed_package_path = os.path.join(
+        sublime.installed_packages_path(),
+        pkg_name + '.sublime-package'
+    )
+    package_path = os.path.join(sublime.packages_path(), pkg_name)
     def path_matches(module):
         file_path = getattr(module, '__file__', '')
         return (
-            file_path == package_base or
-            file_path.startswith(package_base + os.sep)
+            file_path == installed_package_path or
+            file_path.startswith(installed_package_path + os.sep) or
+            file_path == package_path or
+            file_path.startswith(package_path + os.sep)
         )
 
     return {


### PR DESCRIPTION
When `reload_package` tries to find all modules belonging to the package `Foo`, it finds all modules in `sys.modules` whose name equals `Foo` or starts with `Foo.`. This works perfectly most of the time, but it could fail if `Foo` adds a subdirectory to `sys.path` and imports modules from that subdirectory whose names don't begin with `Foo.`.

Consider the following case:

```
TestPackage/
    test.py
    foo_constant.py
    bar/
        bar_constant.py
```

`test.py`:

```python
import sublime
import os.path
import sys

def plugin_loaded():
    sys.path.append(
        os.path.join(sublime.packages_path(), 'TestPackage', 'bar')
    )

    global FOO
    global BAR
    from .foo_constant import FOO
    from bar_constant import BAR

```

`foo_constant.py`:

```python
FOO = 1
```

`bar_constant.py`:

```python
BAR = 2
```

When AutomaticPackageReloader tries to reload `TestPackage`, it will reload `foo_constant.py` because its name is `TestPackage.foo_constant`, but it won't reload `bar_constant.py` because its name is merely `bar_constant` and that doesn't start with `TestPackage.`. You can observe this by modifying `bar_constant.py` to `BAR = 3`, saving (and waiting for AutomaticPackageReloader), typing `import TestPackage.test; TestPackage.test.BAR` into the console, and seeing the output `2`.

This PR instead finds the modules belonging to a package by checking the `__file__` and `__path__` attributes of each module and comparing them to the package's file paths. This should be reliable even if the package munges `sys.path`.