### PR TITLE
Use sublime.find_resources instead of os.listdir to find plugins.

### DIFF
--- a/reloader/reloader.py
+++ b/reloader/reloader.py
@@ -1,6 +1,7 @@
 import sublime
 import sublime_plugin
 import os
+import posixpath
 import threading
 import builtins
 import functools
@@ -182,9 +183,12 @@ def reload_missing(modules, verbose):
 
 
 def reload_plugin(pkg_name):
-    pkg_path = os.path.join(os.path.realpath(sublime.packages_path()), pkg_name)
-    plugins = [pkg_name + "." + os.path.splitext(file_path)[0]
-               for file_path in os.listdir(pkg_path) if file_path.endswith(".py")]
+    plugins = [
+        pkg_name + '.' + posixpath.basename(posixpath.splitext(path)[0])
+        for path in sublime.find_resources("*.py")
+        if posixpath.dirname(path) == 'Packages/'+pkg_name
+    ]
+
     for plugin in plugins:
         sublime_plugin.reload_plugin(plugin)
 


### PR DESCRIPTION
In `reload_plugin`, `os.listdir` was used to find top-level plugins. This fails when the package in question is zipped (such as an installed package). Ordinarily, this wouldn't matter, because reloading is triggered when you edit a package file (which is by definition not zipped). However, there are two situations in which this could fail:

1. You're reloading a file in an override, and non-overridden files in the installed package refer to the overridden file.
2. You're reloading a dependency, and an installed package refers to that dependency.

In either case, `os.listdir` will raise `FileNotFoundError`.

This PR uses `sublime.find_resources` instead of `os.listdir` to find top-level plugin scripts. It should cover both these cases. Outside these cases, there should be no change in behavior.

Note: `posixpath` is used to manipulate the resource paths. This should be correct regardless of the underlying platform. As an alternative, I suggest that [`sublime_lib.ResourcePath`](https://sublimetext.github.io/sublime_lib/#sublime_lib.ResourcePath) might help to simplify this logic and a good deal of other path-related logic in this package. Adding a `sublime_lib` dependency is outside the scope of this PR.