### PR TITLE
Refactor `reload_package`

### DIFF
--- a/package_reloader.py
+++ b/package_reloader.py
@@ -28,17 +28,12 @@ def relative_to_spp(path):
     return None
 
 
-class PackageReloaderListener(sublime_plugin.ViewEventListener):
-    @classmethod
-    def applies_to_primary_view_only(cls):
-        return True
+class PackageReloaderListener(sublime_plugin.EventListener):
 
-    def on_post_save(self):
-        view = self.view
-        if view.is_scratch() or not view.is_primary() or view.settings().get('is_widget'):
+    def on_post_save(self, view):
+        if view.is_scratch() or view.settings().get('is_widget'):
             return
         file_name = view.file_name()
-        print(file_name, view.is_primary(), view.id())
 
         if file_name and file_name.endswith(".py") and relative_to_spp(file_name):
             package_reloader_settings = sublime.load_settings("package_reloader.sublime-settings")
@@ -108,7 +103,6 @@ class PackageReloaderReloadCommand(sublime_plugin.WindowCommand):
             if not console_opened and open_console:
                 self.window.run_command("show_panel", {"panel": "console"})
             try:
-                RELOADING = True
                 reload_package(pkg_name, verbose=pr_settings.get('verbose'))
             except Exception:
                 sublime.status_message("Fail to reload {}.".format(pkg_name))
@@ -116,7 +110,6 @@ class PackageReloaderReloadCommand(sublime_plugin.WindowCommand):
                     self.window.run_command("show_panel", {"panel": "console"})
                 raise
             finally:
-                RELOADING = False
                 progress_bar.stop()
 
             if close_console_on_success:

--- a/package_reloader.py
+++ b/package_reloader.py
@@ -28,12 +28,17 @@ def relative_to_spp(path):
     return None
 
 
-class PackageReloaderListener(sublime_plugin.EventListener):
+class PackageReloaderListener(sublime_plugin.ViewEventListener):
+    @classmethod
+    def applies_to_primary_view_only(cls):
+        return True
 
-    def on_post_save(self, view):
-        if view.is_scratch() or view.settings().get('is_widget'):
+    def on_post_save(self):
+        view = self.view
+        if view.is_scratch() or not view.is_primary() or view.settings().get('is_widget'):
             return
         file_name = view.file_name()
+        print(file_name, view.is_primary(), view.id())
 
         if file_name and file_name.endswith(".py") and relative_to_spp(file_name):
             package_reloader_settings = sublime.load_settings("package_reloader.sublime-settings")
@@ -84,7 +89,7 @@ class PackageReloaderReloadCommand(sublime_plugin.WindowCommand):
         if RELOADING:
             print("Reloader is running.")
             return
-
+        RELOADING = True
         if not pkg_name:
             pkg_name = self.current_package_name
 

--- a/reloader/reloader.py
+++ b/reloader/reloader.py
@@ -110,7 +110,7 @@ def reload_package(pkg_name, dummy=True, verbose=True):
                     sublime_plugin.reload_plugin(plugin)
     except Exception:
         dprint("reload failed.", fill='-')
-        reload_missing(modules, verbose)
+        reload_missing(all_modules, verbose)
         raise
 
     if dummy:


### PR DESCRIPTION
Unifies dependency/package reloading and should do all of the steps in the right order:

1. Determine which dependencies and packages need to be reloaded.
2. Call `sublime_plugin.unload_module` on each plugin.
3. Unload all dependencies.
4. Reload all packages:
  a. Unload all package modules.
  b. Call `sublime_plugin.reload_plugin` on each plugin.
5. Load the dummy package.

When an ordinary package is passed to `reload_package`, the order of events will be the same as before except that `sublime_plugin.unload_module` will not be called on modules other than (top-level) plugins.