### PR TITLE
Preserve lock across reloads.

### DIFF
--- a/package_reloader.py
+++ b/package_reloader.py
@@ -8,7 +8,10 @@ from threading import Thread, Lock
 from .reloader import reload_package, ProgressBar
 
 
-reload_lock = Lock()
+try:
+    reload_lock  # Preserve same lock across reloads
+except NameError:
+    reload_lock = Lock()
 
 
 def casedpath(path):


### PR DESCRIPTION
Even with #27, it is occasionally possible to end up with multiple reloads running simultaneously. I can replicate this by opening `reloader.py` and holding down the save keystroke. This PR ensures that the same lock is used across reloads, which seems to completely prevent the problem.