### PR TITLE
WIP: Rewrite using sublime_plugin.load_module.

### DIFF
--- a/reloader/dprint.py
+++ b/reloader/dprint.py
@@ -1,0 +1,7 @@
+def dprint(*args, fill=None, fill_width=60, **kwargs):
+    if fill is not None:
+        sep = str(kwargs.get('sep', ' '))
+        caption = sep.join(args)
+        args = "{0:{fill}<{width}}".format(caption and caption + sep,
+                                           fill=fill, width=fill_width),
+    print("[Package Reloader]", *args, **kwargs)

--- a/reloader/importer.py
+++ b/reloader/importer.py
@@ -1,0 +1,56 @@
+import builtins
+import imp
+from inspect import ismodule
+
+from .stack_meter import StackMeter
+from .dprint import dprint
+
+
+class ReloadingImporter():
+    def __init__(self, modules, verbose):
+        self._modules_to_reload = set(modules)
+        self._stack_meter = StackMeter()
+        self._verbose = verbose
+
+    def reload(self, module):
+        try:
+            self._modules_to_reload.remove(module)
+        except KeyError:
+            return
+
+        with self._stack_meter as depth:
+            if self._verbose:
+                dprint("reloading", ('| ' * depth) + '|--', module.__name__)
+
+            imp.reload(module)
+
+    def __import__(self, name, globals=None, locals=None, fromlist=(), level=0):
+        module = self._orig___import__(name, globals, locals, fromlist, level)
+
+        self.reload(module)
+
+        if fromlist:
+            from_names = [
+                name
+                for item in fromlist
+                for name in (
+                    getattr(module, '__all__', []) if item == '*' else (item,)
+                )
+            ]
+
+            for name in from_names:
+                value = getattr(module, name, None)
+                if ismodule(value):
+                    self.reload(value)
+
+        return module
+
+    def __enter__(self):
+        self._orig___import__ = __import__
+        builtins.__import__ = self.__import__
+
+        return self.reload
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        builtins.__import__ = self._orig___import__
+        del self._orig___import__

--- a/reloader/reloader.py
+++ b/reloader/reloader.py
@@ -1,76 +1,52 @@
 import sublime
 import sublime_plugin
 import os
-import posixpath
+import os.path
 import threading
-import builtins
-import functools
-import importlib
 import sys
-from inspect import ismodule
-from contextlib import contextmanager
-from .stack_meter import StackMeter
+
+from .dprint import dprint
+from .importer import ReloadingImporter
+from .resolver import resolve_dependencies
 
 
-try:
-    from package_control.package_manager import PackageManager
-
-    def is_dependency(pkg_name):
-        return PackageManager()._is_dependency(pkg_name)
-
-except ImportError:
-    def is_dependency(pkg_name):
-        return False
-
-
-def dprint(*args, fill=None, fill_width=60, **kwargs):
-    if fill is not None:
-        sep = str(kwargs.get('sep', ' '))
-        caption = sep.join(args)
-        args = "{0:{fill}<{width}}".format(caption and caption + sep,
-                                           fill=fill, width=fill_width),
-    print("[Package Reloader]", *args, **kwargs)
-
-
-def path_contains(a, b):
-    return a == b or b.startswith(a + os.sep)
-
-
-def get_package_modules(pkg_name):
-    in_installed_path = functools.partial(
-        path_contains,
-        os.path.join(
-            sublime.installed_packages_path(),
-            pkg_name + '.sublime-package'
+def get_package_modules(package_names):
+    package_path_bases = [
+        p
+        for pkg_name in package_names
+        for p in (
+            os.path.join(
+                sublime.installed_packages_path(),
+                pkg_name + '.sublime-package'
+            ),
+            os.path.join(sublime.packages_path(), pkg_name),
         )
-    )
-
-    in_package_path = functools.partial(
-        path_contains,
-        os.path.join(sublime.packages_path(), pkg_name)
-    )
-
-    def module_in_package(module):
-        file = getattr(module, '__file__', '')
-        paths = getattr(module, '__path__', ())
-        return (
-            in_installed_path(file) or any(map(in_installed_path, paths)) or
-            in_package_path(file) or any(map(in_package_path, paths))
-        )
-
-    return {
-        name: module
-        for name, module in sys.modules.items()
-        if module_in_package(module)
-    }
-
-
-def package_plugins(pkg_name):
-    return [
-        pkg_name + '.' + posixpath.basename(posixpath.splitext(path)[0])
-        for path in sublime.find_resources("*.py")
-        if posixpath.dirname(path) == 'Packages/'+pkg_name
     ]
+
+    def module_paths(module):
+        try:
+            yield module.__file__
+        except AttributeError:
+            pass
+
+        try:
+            yield from module.__path__
+        except AttributeError:
+            pass
+
+    for module in sys.modules.values():
+        try:
+            base, path = next(
+                (base, path)
+                for path in module_paths(module)
+                for base in package_path_bases
+                if path == base or path.startswith(base + os.sep)
+            )
+        except StopIteration:
+            continue
+        else:
+            is_plugin = (os.path.dirname(path) == base)
+            yield module, is_plugin
 
 
 def reload_package(pkg_name, dummy=True, verbose=True):
@@ -78,83 +54,39 @@ def reload_package(pkg_name, dummy=True, verbose=True):
         dprint("error:", pkg_name, "is not loaded.")
         return
 
-    if is_dependency(pkg_name):
-        dependencies, packages = resolve_dependencies(pkg_name)
-    else:
-        dependencies = set()
-        packages = {pkg_name}
-
     if verbose:
         dprint("begin", fill='=')
 
-    all_modules = {
-        module_name: module
-        for pkg_name in dependencies | packages
-        for module_name, module in get_package_modules(pkg_name).items()
-    }
+    packages = resolve_dependencies(pkg_name)
+    modules = list(get_package_modules(packages))
+
+    sorted_modules = sorted(
+        [module for module, is_plugin in modules],
+        key=lambda module: module.__name__.split('.')
+    )
+
+    plugins = [
+        module
+        for module, is_plugin in modules
+        if is_plugin
+    ]
 
     # Tell Sublime to unload plugins
-    for pkg_name in packages:
-        for plugin in package_plugins(pkg_name):
-            module = sys.modules.get(plugin)
-            if module:
-                sublime_plugin.unload_module(module)
+    for module in plugins:
+        sublime_plugin.unload_module(module)
 
-    # Unload modules
-    for module_name in all_modules:
-        sys.modules.pop(module_name)
+    with ReloadingImporter(sorted_modules, verbose) as reload:
+        for module in sorted_modules:
+            reload(module)
 
-    # Reload packages
-    try:
-        with intercepting_imports(all_modules, verbose), importing_fromlist_aggresively(all_modules):
-            for pkg_name in packages:
-                for plugin in package_plugins(pkg_name):
-                    sublime_plugin.reload_plugin(plugin)
-    except Exception:
-        dprint("reload failed.", fill='-')
-        reload_missing(all_modules, verbose)
-        raise
+    for module in plugins:
+        sublime_plugin.load_module(module)
 
     if dummy:
         load_dummy(verbose)
 
     if verbose:
         dprint("end", fill='-')
-
-
-def resolve_dependencies(root_name):
-    """Given the name of a dependency, return all dependencies and packages
-    that require that dependency, directly or indirectly.
-    """
-    manager = PackageManager()
-
-    all_packages = manager.list_packages()
-    all_dependencies = manager.list_dependencies()
-
-    recursive_dependencies = set()
-    dependent_packages = set()
-
-    dependency_relationships = {
-        name: manager.get_dependencies(name)
-        for name in all_packages + all_dependencies
-    }
-
-    def rec(name):
-        if name in recursive_dependencies:
-            return
-
-        recursive_dependencies.add(name)
-
-        for dep_name in all_dependencies:
-            if name in dependency_relationships[dep_name]:
-                rec(dep_name)
-
-        for pkg_name in all_packages:
-            if name in dependency_relationships[pkg_name]:
-                dependent_packages.add(pkg_name)
-
-    rec(root_name)
-    return (recursive_dependencies, dependent_packages)
 
 
 def load_dummy(verbose):
@@ -201,76 +133,3 @@ def load_dummy(verbose):
     condition.acquire()
     condition.wait(30)  # 30 seconds should be enough for all regular usages
     condition.release()
-
-
-def reload_missing(modules, verbose):
-    missing_modules = {name: module for name, module in modules.items()
-                       if name not in sys.modules}
-    if missing_modules:
-        if verbose:
-            dprint("reload missing modules")
-        for name in missing_modules:
-            if verbose:
-                dprint("reloading missing module", name)
-            sys.modules[name] = modules[name]
-
-
-@contextmanager
-def intercepting_imports(modules, verbose):
-    finder = FilterFinder(modules, verbose)
-    sys.meta_path.insert(0, finder)
-    try:
-        yield
-    finally:
-        if finder in sys.meta_path:
-            sys.meta_path.remove(finder)
-
-
-@contextmanager
-def importing_fromlist_aggresively(modules):
-    orig___import__ = builtins.__import__
-
-    @functools.wraps(orig___import__)
-    def __import__(name, globals=None, locals=None, fromlist=(), level=0):
-        module = orig___import__(name, globals, locals, fromlist, level)
-        if fromlist and module.__name__ in modules:
-            if '*' in fromlist:
-                fromlist = list(fromlist)
-                fromlist.remove('*')
-                fromlist.extend(getattr(module, '__all__', []))
-            for x in fromlist:
-                if ismodule(getattr(module, x, None)):
-                    from_name = '{}.{}'.format(module.__name__, x)
-                    if from_name in modules:
-                        importlib.import_module(from_name)
-        return module
-
-    builtins.__import__ = __import__
-    try:
-        yield
-    finally:
-        builtins.__import__ = orig___import__
-
-
-class FilterFinder:
-    def __init__(self, modules, verbose):
-        self._modules = modules
-        self._stack_meter = StackMeter()
-        self._verbose = verbose
-
-    def find_module(self, name, path=None):
-        if name in self._modules:
-            return self
-
-    def load_module(self, name):
-        module = self._modules[name]
-        sys.modules[name] = module  # restore the module back
-        with self._stack_meter as depth:
-            if self._verbose:
-                dprint("reloading", ('| ' * depth) + '|--', name)
-            try:
-                return module.__loader__.load_module(name)
-            except Exception:
-                if name in sys.modules:
-                    del sys.modules[name]  # to indicate an error
-                raise

--- a/reloader/resolver.py
+++ b/reloader/resolver.py
@@ -1,0 +1,35 @@
+try:
+    from package_control.package_manager import PackageManager
+
+except ImportError:
+    def resolve_dependencies(root_name):
+        return {root_name}
+
+else:
+    def resolve_dependencies(root_name):
+        """Given the name of a dependency, return all dependencies and packages
+        that require that dependency, directly or indirectly.
+        """
+        manager = PackageManager()
+        everything = manager.list_packages() + manager.list_dependencies()
+
+        recursive_dependencies = set()
+
+        dependency_relationships = {
+            name: manager.get_dependencies(name)
+            for name in everything
+        }
+
+        def rec(name):
+            if name in recursive_dependencies:
+                return
+
+            recursive_dependencies.add(name)
+
+            for pkg_name in everything:
+                if name in dependency_relationships[pkg_name]:
+                    rec(pkg_name)
+
+        rec(root_name)
+
+        return recursive_dependencies


### PR DESCRIPTION
Sublime 3189 provides a new [`sublime_plugin.load_module()` function](https://github.com/SublimeTextIssues/Core/issues/2590). This allows us to load a module without using Sublime's reloading code, which may let us substantially simplify the reloading code. This PR is a first draft of what such a simplification may look like.

The current reloading algorithm goes like this:

0. Resolve dependencies, find modules to reload.
1. Unload plugins (using `sublime_plugin.unload_module`).
2. Remove modules from `sys.modules`.
3. Reload plugins (using `sublime_plugin.reload_plugin`). This should reload the modules.

Step 2 is not desirable by itself, but it's necessary because `sublime_plugin.reload_plugin` both reloads the given module and registers its contents with Sublime, and the reloading part works differently depending on whether the given module is in `sys.modules`. If it is, then `reload_plugin` will call `unload_module`, which we already called in step 1. Therefore, it has proved necessary to manually remove items from `sys.modules` to invoke the second case in `reload_plugin`. That case, in turn, calls `importlib.import_module` directly rather than using `__import__`, which means that we have to temporarily add a new finder to `sys.meta_path` to intercept the top-level plugin imports and actually reload modules.

This PR uses the new `sublime_plugin.load_module`, which only registers the given module's contents with Sublime and does not attempt to unload the plugin contents or reload the module. (In essence, `load_module` is the counterpart to `unload_module`, whereas `reload_plugin` is more like `unload_plugin`.) This allows the following algorithm:

0. Resolve dependencies, find modules to reload.
1. Unload plugins (using `sublime_plugin.unload_module`).
2. Reload modules.
3. Load plugins (using `sublime_plugin.load_module`).

Because `load_module` won't trigger module reloads, we can do it ourselves. The implementation in the PR does this by patching `__import__` in a similar way to `importing_fromlist_aggresively` (and subsuming the latter). This ensures that modules are reloaded in the correct order without needing to modify either `sys.modules` or `sys.meta_path`.

The advantages of this approach are:

- It's less code.
- It patches fewer things -- still `__import__`, but no longer `sys.modules` or `sys.meta_path`.
- It's less reliant on the internals of `sublime_plugin`.
- All modules remain in place during the reload, which should reduce the likelihood of errors when other code calls a module that's being reloaded.
- Modules are never removed, so we don't need to put them back (such as in case of an error).

Disadvantages may include:

- It's a substantial change.
- It may behave differently with some kinds of dynamic module loading.
- We'll have to provide a fallback implementation of `load_module` for older versions of Sublime. (This is messy, but it won't break on us because old versions won't change.)

This PR isn't ready; I need to do more testing and write the fallback code. The approach should be pretty stable, though, so I'd appreciate any comments or feedback.