### PR TITLE
Removes is_enabled from PackageReloaderReloadCommand

### DIFF
--- a/package_reloader.py
+++ b/package_reloader.py
@@ -55,9 +55,6 @@ class PackageReloaderToggleReloadOnSaveCommand(sublime_plugin.WindowCommand):
 
 
 class PackageReloaderReloadCommand(sublime_plugin.WindowCommand):
-    def is_enabled(self):
-        return self.current_package_name is not None
-
     @property
     def current_package_name(self):
         view = self.window.active_view()


### PR DESCRIPTION
The two lines of code I deleted made it impossible to use the plugin from outside of a package, even though it was clearly designed to be used in this way... Just look at the `pkg_name` arg!

Removing them makes it possible to call `package_reloader_reload` from outside of a package, to reload any package from any directory.

In any case, the plugin already has code that prints an error message to the console if a user calls the plugin from a directory that's not a Sublime Text package: `print("Cannot detect package name.")`.

I don't think this requires any updates to the docs, but I would be glad to add a section that explains how a user could create a key binding to reload a specific package.