### PR TITLE
Detect modules loaded via symlinks but opened by a different path

### DIFF
--- a/package_reloader.py
+++ b/package_reloader.py
@@ -38,7 +38,6 @@ else:
     def relative_to_spp(path):
         spp = os.path.realpath(sublime.packages_path())
         if path.startswith(spp + os.sep):
-            print("This is: ", path[len(spp):])
             return path[len(spp):]
 
         for name in os.listdir(spp):


### PR DESCRIPTION
It's legal to have folder symlinks immediately inside the Sublime package path (SPP):
`SPP/symlink -> ~/A/B/C`

Sublime will happily load everything under `~/A/B/C/` as ordinary package contents. It's often convenient to arrange things like this because oftentimes you don't want to put the code your working on directly under `~/.config/sublime-text-3/Packages/` but still want things to get automatically loaded into Sublime.

Now the problem is when you open a Python module from `~/A/B/C/`, the Automatic Package Reloader won't recognize it as a relevant file and won't reload the respective package's modules. This pull request remedies that by scanning all folder symlinks under SPP and trying to match the given path against the links' destinations.