### PR TITLE
Fix attribute error due to Package Control method renaming

### DIFF
--- a/reloader/resolver.py
+++ b/reloader/resolver.py
@@ -11,13 +11,14 @@ else:
         that require that dependency, directly or indirectly.
         """
         manager = PackageManager()
-        everything = manager.list_packages() + manager.list_dependencies()
+        packages = manager.list_packages()
+        dependencies = map(lambda lib: lib.name, manager.list_libraries())
+        everything = list(packages) + list(dependencies)        
 
         recursive_dependencies = set()
 
         dependency_relationships = {
-            name: manager.get_dependencies(name)
-            for name in everything
+            name: manager.get_libraries(name) for name in everything
         }
 
         def rec(name):

--- a/reloader/resolver.py
+++ b/reloader/resolver.py
@@ -12,13 +12,11 @@ else:
         """
         manager = PackageManager()
         packages = manager.list_packages()
-        dependencies = map(lambda lib: lib.name, manager.list_libraries())
-        everything = list(packages) + list(dependencies)        
 
         recursive_dependencies = set()
 
         dependency_relationships = {
-            name: manager.get_libraries(name) for name in everything
+            name: manager.get_libraries(name) for name in packages
         }
 
         def rec(name):
@@ -27,7 +25,7 @@ else:
 
             recursive_dependencies.add(name)
 
-            for pkg_name in everything:
+            for pkg_name in packages:
                 if name in dependency_relationships[pkg_name]:
                     rec(pkg_name)
 


### PR DESCRIPTION
Package Control has just released [version 4.0.0](https://github.com/wbond/package_control/releases/tag/4.0.0) a few days ago, including [changes to some methods](https://github.com/wbond/package_control/blob/a59d9ef842d7bc3f20df263ec209890c40fd2e47/package_control/package_manager.py) that this package depends on. If you reload a package, this error will occur:
```
File "/home/phhuyhoang/.config/sublime-text-3/Packages/AutomaticPackageReloader/package_reloader.py", line 117, in run_async
    package, dependencies=dependencies, extra_modules=extra_modules, verbose=verbose)
  File "/home/phhuyhoang/.config/sublime-text-3/Packages/AutomaticPackageReloader/reloader/reloader.py", line 80, in reload_package
    for parent in resolve_parents(package):
  File "/home/phhuyhoang/.config/sublime-text-3/Packages/AutomaticPackageReloader/reloader/resolver.py", line 14, in resolve_parents
    everything = manager.list_packages() + manager.list_dependencies()
AttributeError: 'PackageManager' object has no attribute 'list_dependencies'
```
This PR fixes that bug.
Anyway, this is a great package that I've been using for two years. Love it.