### PR TITLE
Fix Package Control 4 compatibility

### DIFF
--- a/reloader/resolver.py
+++ b/reloader/resolver.py
@@ -11,12 +11,12 @@ else:
         that require that dependency, directly or indirectly.
         """
         manager = PackageManager()
-        everything = manager.list_packages() + manager.list_dependencies()
+        everything = manager.list_packages()
 
         recursive_dependencies = set()
 
         dependency_relationships = {
-            name: manager.get_dependencies(name)
+            name: manager.get_libraries(name)
             for name in everything
         }
 


### PR DESCRIPTION
Internal APIs changed due to transition from "dependencies" to "libraries".

Note classical dependency packages are no longer supported in favor of organizing python packages in `$data/Libs` paths.

This step was required to support multiple python plugin hosts.

As a result `manager.list_dependencies()` is obsolete. Replacing by `manager.list_libraries()` doesn't not make sense as libraries are not organized under Packages and can't be reloaded with current implementation of AutomaticPackageReloader.