### PR TITLE
Refactor AutomaticPackageReloader33 creation

### DIFF
--- a/package_reloader.py
+++ b/package_reloader.py
@@ -3,6 +3,7 @@ import sublime
 import os
 import sys
 import shutil
+from textwrap import dedent
 from threading import Thread, Lock
 
 from .reloader import reload_package
@@ -144,9 +145,18 @@ def plugin_loaded():
         APR33 = os.path.join(sublime.packages_path(), "AutomaticPackageReloader33")
         if not os.path.exists(APR33):
             os.makedirs(APR33)
-        data = sublime.load_resource("Packages/AutomaticPackageReloader/py33/package_reloader.py")
         with open(os.path.join(APR33, "package_reloader.py"), 'w') as f:
-            f.write(data.replace("\r\n", "\n"))
+            f.write(
+                dedent(
+                    """
+                    from AutomaticPackageReloader import package_reloader as package_reloader38  # noqa
+
+
+                    class PackageReloader33ReloadCommand(package_reloader38.PackageReloaderReloadCommand):
+                        pass
+                    """
+                ).lstrip()
+            )
         with open(os.path.join(APR33, ".package_reloader.json"), 'w') as f:
             f.write("{\"dependencies\" : [\"AutomaticPackageReloader\"]}")
 

--- a/package_reloader.py
+++ b/package_reloader.py
@@ -143,22 +143,30 @@ class PackageReloaderReloadCommand(sublime_plugin.WindowCommand):
 def plugin_loaded():
     if sys.version_info >= (3, 8):
         APR33 = os.path.join(sublime.packages_path(), "AutomaticPackageReloader33")
-        if not os.path.exists(APR33):
-            os.makedirs(APR33)
-        with open(os.path.join(APR33, "package_reloader.py"), 'w') as f:
-            f.write(
-                dedent(
-                    """
-                    from AutomaticPackageReloader import package_reloader as package_reloader38  # noqa
+        os.makedirs(APR33, exist_ok=True)
+
+        try:
+            # write only if not exists to avoid ST reloading the package twice at each startup
+            with open(os.path.join(APR33, "package_reloader.py"), 'x') as f:
+                f.write(
+                    dedent(
+                        """
+                        from AutomaticPackageReloader import package_reloader as package_reloader38  # noqa
 
 
-                    class PackageReloader33ReloadCommand(package_reloader38.PackageReloaderReloadCommand):
-                        pass
-                    """
-                ).lstrip()
-            )
-        with open(os.path.join(APR33, ".package_reloader.json"), 'w') as f:
-            f.write("{\"dependencies\" : [\"AutomaticPackageReloader\"]}")
+                        class PackageReloader33ReloadCommand(package_reloader38.PackageReloaderReloadCommand):
+                            pass
+                        """
+                    ).lstrip()
+                )
+        except FileExistsError:
+            pass
+
+        try:
+            with open(os.path.join(APR33, ".package_reloader.json"), 'w') as f:
+                f.write("{\"dependencies\" : [\"AutomaticPackageReloader\"]}")
+        except FileExistsError:
+            pass
 
 
 def plugin_unloaded():

--- a/py33/package_reloader.py
+++ b/py33/package_reloader.py
@@ -1,5 +1,0 @@
-from AutomaticPackageReloader import package_reloader as package_reloader38  # noqa
-
-
-class PackageReloader33ReloadCommand(package_reloader38.PackageReloaderReloadCommand):
-    pass


### PR DESCRIPTION
Create python 3.3 plugin using static text instead of loading source from file to avoid `sublime.load_resource()` API call. 

_Content is simple enough to be maintained as multi-line string._