### PR TITLE
Fix reloading importer

### DIFF
--- a/reloader/importer.py
+++ b/reloader/importer.py
@@ -1,12 +1,18 @@
 import builtins
-import imp
 from inspect import ismodule
+
+try:
+    # python 3.8+
+    from importlib import reload as reload_module
+except:
+    # python 3.3
+    from imp import reload as reload_module
 
 from .stack_meter import StackMeter
 from .dprint import dprint
 
 
-class ReloadingImporter():
+class ReloadingImporter:
     def __init__(self, modules, verbose):
         self._modules_to_reload = set(modules)
         self._stack_meter = StackMeter()
@@ -16,18 +22,16 @@ class ReloadingImporter():
         try:
             self._modules_to_reload.remove(module)
         except KeyError:
-            return
+            return module
 
         with self._stack_meter as depth:
             if self._verbose:
                 dprint("reloading", ('| ' * depth) + '|--', module.__name__)
 
-            imp.reload(module)
+            return reload_module(module)
 
     def __import__(self, name, globals=None, locals=None, fromlist=(), level=0):
-        module = self._orig___import__(name, globals, locals, fromlist, level)
-
-        self.reload(module)
+        module = self.reload(self._orig___import__(name, globals, locals, fromlist, level))
 
         if fromlist:
             from_names = [


### PR DESCRIPTION
This commit...

1. uses `importlib.reload()` if present as `imp` module is deprecated as of python 3.4 and removed in python 3.12. New library is prepared to work well with newer `__spec__` based import machinery.
2. make sure to resolve `fromlist` using reloaded module