### PR TITLE
Drop dummy module installing

### DIFF
--- a/reloader/__init__.py
+++ b/reloader/__init__.py
@@ -1,1 +1,1 @@
-from .reloader import reload_package, load_dummy
+from .reloader import reload_package


### PR DESCRIPTION
Resolves #45

This PR drops installation/removal of a dummy package, which was meant to trigger ST reloading plugins.

That's obsolete as `reload_package()`...

1. calls `sublime_plugin.unload_module()` to remove all plugin hooks (Commands & Listeners)
2. reloads all plugins (and their imports)
3. calls `sublime_plugin.load_module(module)` to re-instantiate all plugin hooks (Commands & Listeners)

That's all which is needed to reload package's plugins.

Note: This commit removes `threading` and sorts remaining imports.