### PR TITLE
Remove duplicate dummy reloading

### DIFF
--- a/reloader/reloader.py
+++ b/reloader/reloader.py
@@ -71,9 +71,6 @@ def reload_package(package, dependencies=[], extra_modules=[], dummy=True, verbo
     if verbose:
         dprint("begin", fill='=')
 
-    if dummy:
-        load_dummy(verbose)
-
     packages = [package] + dependencies
     parents = set()
     for package in packages:


### PR DESCRIPTION
Installing and removing the _dummy plugin is needed only once after all plugins have been reloaded to trigger ST to pick up new command and event listener instances from reloaded modules.

The removed call had no effect as it was called before unloading plugins (see line 91..93).

